### PR TITLE
`getFileHandle(create: true)` throws `NotFoundError` in a valid direcotry.  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- nullable return type of `getFileHandle` and `getDirectoryHandle` in `FileSystemDirectoryHandle` to be non-nullable. 
+Methods throw `NotFoundError` instead of returning `null`. ([issue #1])
 
 ------------------------
 
@@ -90,3 +93,6 @@ if (handle.kind == FileSystemKind.file) {}
 [1.0.0]: https://github.com/poirierlouis/file_system_access_api/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/poirierlouis/file_system_access_api/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/poirierlouis/file_system_access_api/releases/tag/v0.1.0
+
+<!-- Table of issues -->
+[issue #1]: https://github.com/poirierlouis/file_system_access_api/issues/1

--- a/example/compression_web_worker.dart
+++ b/example/compression_web_worker.dart
@@ -61,10 +61,6 @@ void onStartAction(dynamic data) async {
     final src = await root.getFileHandle(srcFileName);
     final dst = await root.getFileHandle(dstFileName, create: true);
 
-    if (src == null || dst == null) {
-      sendAbort();
-      return;
-    }
     sendReady();
 
     final syncSrc = await src.createSyncAccessHandle();

--- a/example/example.dart
+++ b/example/example.dart
@@ -70,9 +70,6 @@ Future<void> originPrivateFileSystem() async {
   final handle = await root.getFileHandle("pubspec.yaml", create: true);
   final directory = await root.getDirectoryHandle("lib", create: true);
 
-  if (handle == null || directory == null) {
-    return;
-  }
   // Rename file
   await handle.rename("main.dart");
 
@@ -96,20 +93,21 @@ Future<void> webWorker() async {
   if (root == null) {
     return;
   }
-  final source = await root.getFileHandle("linux.iso");
-  final destination = await root.getFileHandle("xunil.iso", create: true);
+  try {
+    final source = await root.getFileHandle("linux.iso");
+    final destination = await root.getFileHandle("xunil.iso", create: true);
 
-  if (source == null || destination == null) {
-    return;
+    FileSystemSyncAccessHandle src = await source.createSyncAccessHandle();
+    FileSystemSyncAccessHandle dst = await destination.createSyncAccessHandle();
+    Uint8List buffer = Uint8List(src.getSize());
+
+    src.read(buffer);
+    dst.write(buffer);
+    dst.flush();
+
+    src.close();
+    dst.close();
+  } on NotFoundError {
+    print("'linux.iso' file not found!");
   }
-  FileSystemSyncAccessHandle src = await source.createSyncAccessHandle();
-  FileSystemSyncAccessHandle dst = await destination.createSyncAccessHandle();
-  Uint8List buffer = Uint8List(src.getSize());
-
-  src.read(buffer);
-  dst.write(buffer);
-  dst.flush();
-
-  src.close();
-  dst.close();
 }

--- a/example/tree/view_directory_node.dart
+++ b/example/tree/view_directory_node.dart
@@ -126,10 +126,6 @@ class ViewDirectoryNode extends ViewNode<FileSystemDirectoryHandle> {
     }
     try {
       final directory = await handle.getDirectoryHandle(fileName, create: true);
-
-      if (directory == null) {
-        return;
-      }
       final node = ViewNode.fromHandle(directory, depth, parent: this, isPrivate: isPrivate);
 
       children.add(node);
@@ -152,10 +148,6 @@ class ViewDirectoryNode extends ViewNode<FileSystemDirectoryHandle> {
     }
     try {
       final file = await handle.getFileHandle(fileName, create: true);
-
-      if (file == null) {
-        return;
-      }
       final node = ViewNode.fromHandle(file, depth, parent: this, isPrivate: isPrivate);
 
       children.add(node);

--- a/lib/src/api/file_system_directory_handle.dart
+++ b/lib/src/api/file_system_directory_handle.dart
@@ -56,7 +56,7 @@ extension JSFileSystemDirectoryHandle on FileSystemDirectoryHandle {
   /// Throws a [TypeMismatchError] if the named entry is a directory and not a file.
   /// Throws a [NotFoundError] if file doesn't exist and the create option is set to false or this requested directory
   /// could not be found at the time operation was processed.
-  Future<FileSystemFileHandle?> getFileHandle(String name, {bool create = false}) async {
+  Future<FileSystemFileHandle> getFileHandle(String name, {bool create = false}) async {
     try {
       final options = [name, FileSystemGetFileOptions(create: create)];
       dynamic handle = await promiseToFuture(callMethod(this, "getFileHandle", options));
@@ -89,14 +89,11 @@ extension JSFileSystemDirectoryHandle on FileSystemDirectoryHandle {
   /// Throws a [TypeMismatchError] if the returned entry is a file and not a directory.
   /// Throws a [NotFoundError] if directory doesn't exist and the create option is set to false or this requested
   /// directory could not be found at the time operation was processed.
-  Future<FileSystemDirectoryHandle?> getDirectoryHandle(String name, {bool create = false}) async {
+  Future<FileSystemDirectoryHandle> getDirectoryHandle(String name, {bool create = false}) async {
     try {
       final options = [name, FileSystemGetDirectoryOptions(create: create)];
       dynamic handle = await promiseToFuture(callMethod(this, "getDirectoryHandle", options));
 
-      if (handle == null || handle == undefined) {
-        return null;
-      }
       return handle as FileSystemDirectoryHandle;
     } catch (error) {
       if (jsIsNativeError(error, "NotAllowedError")) {


### PR DESCRIPTION
Change `getFileHandle` and `getDirectoryHandle` to return a non-nullable type as methods throws a `NotFoundError` otherwise.